### PR TITLE
Fix the place of element background-job following xml schema

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,13 +25,13 @@
     <dependencies>
         <nextcloud min-version="24" max-version="26"/>
     </dependencies>
+	<background-jobs>
+		<job>OCA\Secrets\Cron\SecretCleanup</job>
+	</background-jobs>
     <navigations>
         <navigation>
             <name>Secrets</name>
             <route>secrets.page.index</route>
         </navigation>
     </navigations>
-	<background-jobs>
-		<job>OCA\Secrets\Cron\SecretCleanup</job>
-	</background-jobs>
 </info>


### PR DESCRIPTION
Looking https://apps.nextcloud.com/schema/apps/info.xsd the element `background-jobs` need to be after element `dependencies`.

I identified this problem looking the info.xml in my IDE (codium) that blame the problem:

![Screenshot_20221214_130713](https://user-images.githubusercontent.com/1079143/207647094-2d7be046-cec6-4ee4-b45c-85d51dae6c6e.png)

ref: #7 