### PR TITLE
Fix infinite loop if database already has entries

### DIFF
--- a/lib/Migration/Version1001Date20230122142756.php
+++ b/lib/Migration/Version1001Date20230122142756.php
@@ -76,8 +76,7 @@ class Version1001Date20230122142756 extends SimpleMigrationStep {
 		$results = $qb->select('id', 'iv')
 			->from('secrets')
 			->executeQuery();
-		$secret = $results->fetch();
-		while ($secret) {
+		while ($secret = $results->fetch()) {
 			$qb = $this->connection->getQueryBuilder();
 			$qb->update("secrets")
 				->where($qb->expr()->eq('id', $qb->createNamedParameter($secret['id'])))


### PR DESCRIPTION
This PR fixes the endless running upgrade process of the app if the database already contains entries before the migration 'Version1001Date20230122142756' was applied.

This might be related to #23 - with this PR deleting the database table should no longer be necessary.