### PR TITLE
fix: log warning

### DIFF
--- a/lib/Db/SecretMapper.php
+++ b/lib/Db/SecretMapper.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
  * @template-extends QBMapper<Note>
  */
 class SecretMapper extends QBMapper {
+	private LoggerInterface $logger;
 	public function __construct(IDBConnection $db, LoggerInterface $logger) {
 		$this->logger = $logger;
 		parent::__construct($db, 'secrets', Secret::class);


### PR DESCRIPTION
Prevent the follow warnign at nextcloud.log file:

```
Creation of dynamic property OCA\\Secrets\\Db\\SecretMapper::$logger is deprecated at /var/www/html/custom_apps/secrets/lib/Db/SecretMapper.php#22
```