### PR TITLE
fix: undefined property

### DIFF
--- a/lib/Controller/SecretApiController.php
+++ b/lib/Controller/SecretApiController.php
@@ -206,7 +206,7 @@ class SecretApiController extends OCSController {
 	public function delete(string $uuid): DataResponse {
 		try {
 			$secret = $this->service->delete($uuid, $this->userId);
-			return new DataResponse(['message' => "Secret '$secret->getTitle()' has been deleted"]);
+			return new DataResponse(['message' => "Secret '{$secret->getTitle()}' has been deleted"]);
 		} catch (SecretNotFound $e) {
 			return new DataResponse(['message' => "No secret found with uuid '$uuid'"], Http::STATUS_NOT_FOUND);
 		}


### PR DESCRIPTION
I got an error on my instance when a Secret was retrieved and the frontend sent the DELETE to `SecretApiController::delete`

The fixed issue:
```json
{
    "message":"Undefined property: OCA\\Secrets\\Db\\Secret::$getTitle at /var/www/html/custom_apps/secrets/lib/Controller/SecretApiController.php#209"
}
```

I changed the interpolation way adding {