### PR TITLE
Added current date to new secret title

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -193,7 +193,7 @@ export default {
 				expiryDate.setDate((new Date()).getDate() + 7)
 				this.secrets.push({
 					uuid: '',
-					title: t('secrets', 'New Secret'),
+					title: t('secrets', 'New Secret' ) + " " + (new Date()).getDate(),
 					password: '',
 					pwHash: null,
 					key,


### PR DESCRIPTION
Hello,

i added the current date to the default "New Secret" title, because if i create a few new secrets and dont change the title, i cannot identity when i created them. Most of the time the users wont change the default secret title. This feature will help them.

Thanks
Regards
Hannes